### PR TITLE
ci(regenerate): fix regenerate

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -3,6 +3,10 @@ name: Regenerate parser
 on:
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true


### PR DESCRIPTION
Fix invalid workflow file:
```
Invalid workflow file: .github/workflows/regenerate.yml#L11
The workflow is not valid. .github/workflows/regenerate.yml (Line: 11, Col: 3): Error calling workflow 'tree-sitter/workflows/.github/workflows/regenerate.yml@main'. 
The workflow is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.
```