### PR TITLE
ci: only run fuzz-scanner on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Fuzz scanner
         uses: tree-sitter/fuzz-action@v4
-        if: steps.scanner-check.outputs.changed == 'true'
+        if: steps.scanner-check.outputs.changed == 'true' && ${{runner.os == 'Linux'}}
       - name: Run tests
         uses: tree-sitter/parser-test-action@v2
         with:


### PR DESCRIPTION
I also wonder why we use the fuzz-scanner as a separate job and as a step for the test-job, IMO we should remove the step at the test-job, instead of running it twice