### PR TITLE
Add .gitignore and .editorconfig files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{json,toml,yml,gyp}]
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.{c,cc,h}]
+indent_style = space
+indent_size = 4
+
+[*.{py,pyi}]
+indent_style = space
+indent_size = 4
+
+[*.swift]
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab
+indent_size = 8
+
+[Makefile]
+indent_style = tab
+indent_size = 8

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Rust artifacts
+Cargo.lock
+target/
+
+# Node artifacts
+build/
+node_modules/
+*.tgz
+
+# Swift artifacts
+.build/
+
+# Go artifacts
+go.sum
+_obj/
+
+# Python artifacts
+.venv/
+dist/
+*.egg-info
+*.whl
+
+# C artifacts
+*.a
+*.so
+*.so.*
+*.dylib
+*.dll
+*.pc
+
+# Example dirs
+/examples/*/
+
+# Grammar volatiles
+dsl.d.ts
+*.wasm
+*.obj
+*.o


### PR DESCRIPTION
Both files were deleted in https://github.com/tree-sitter-grammars/template/commit/02d99188dc2cbf3a601f3d549108431d5fbd4555, but it doesn't look like that was intentional.

If it was intentional, feel free to close this PR 🙂