### PR TITLE
ci(setup): fix missing delimiter in sed expression

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -68,7 +68,7 @@ jobs:
             -e 's|/tree-sitter/.*|/${{github.repository}}"|'
           sed -i .github/ISSUE_TEMPLATE/bug_report.yml \
             -e 's/PARSER_NAME/${{env.PARSER_NAME}}/' \
-            -e 's/tree-sitter-grammars/${{env.REPO_OWNER}}'
+            -e 's/tree-sitter-grammars/${{env.REPO_OWNER}}/'
           sed -i .github/ISSUE_TEMPLATE/feature_request.yml \
             -e 's/PARSER_NAME/${{env.PARSER_NAME}}/'
           mv .github/not-dependabot.yml .github/dependabot.yml


### PR DESCRIPTION
This was causing the setup to fail.

![image](https://github.com/user-attachments/assets/78e6ce42-749d-49cc-9600-2bb2cb09cab3)