### PR TITLE
ci(setup): replace multiple occurrences in issue template

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -70,7 +70,7 @@ jobs:
             -e 's/PARSER_NAME/${{env.PARSER_NAME}}/' \
             -e 's/tree-sitter-grammars/${{env.REPO_OWNER}}/'
           sed -i .github/ISSUE_TEMPLATE/feature_request.yml \
-            -e 's/PARSER_NAME/${{env.PARSER_NAME}}/'
+            -e 's/PARSER_NAME/${{env.PARSER_NAME}}/g'
           mv .github/not-dependabot.yml .github/dependabot.yml
         env:
           REPO_OWNER: ${{github.repository_owner}}


### PR DESCRIPTION
feature_request.yml contains more than one occurrence of PARSER_NAME on the same line, but sed only replaces the first match by default.

The offending line:

https://github.com/tree-sitter-grammars/template/blob/5efe41fc92bd07a634a195c859128833e5dcf374/.github/ISSUE_TEMPLATE/feature_request.yml?plain=1#L36