### PR TITLE
ci(setup): use REPO_NAME in urls

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Before** reporting an issue, make sure to search [existing issues](https://github.com/tree-sitter-grammars/tree-sitter-PARSER_NAME/issues).
+        **Before** reporting an issue, make sure to search [existing issues](https://github.com/tree-sitter-grammars/REPO_NAME/issues).
         If your issue is related to a bug in your editor-experience because your editor *leverages* tree-sitter and this parser, then it is likely your issue does *NOT* belong here and belongs in the relevant editor's repository.
   - type: checkboxes
     attributes:
@@ -15,7 +15,7 @@ body:
       options:
         - label: I have read all the [tree-sitter docs](https://tree-sitter.github.io/tree-sitter/using-parsers) if it relates to using the parser
           required: false
-        - label: I have searched the existing issues of tree-sitter-PARSER_NAME
+        - label: I have searched the existing issues of REPO_NAME
           required: true
   - type: input
     attributes:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -37,6 +37,7 @@ jobs:
         run: |-
           sed -i README.md \
             -e 's/PARSER_NAME/${{env.PARSER_NAME}}/' \
+            -e 's/REPO_NAME/${{env.REPO_NAME}}/' \
             -e 's/tree-sitter-grammars/${{env.REPO_OWNER}}/'
           sed -i LICENSE -e 's/AUTHOR_NAME/${{env.AUTHOR_NAME}}/'
           sed -i grammar.js \
@@ -69,6 +70,7 @@ jobs:
             -e 's|/tree-sitter/.*|/${{github.repository}}"|'
           sed -i .github/ISSUE_TEMPLATE/bug_report.yml \
             -e 's/PARSER_NAME/${{env.PARSER_NAME}}/' \
+            -e 's/REPO_NAME/${{env.REPO_NAME}}/' \
             -e 's/tree-sitter-grammars/${{env.REPO_OWNER}}/'
           sed -i .github/ISSUE_TEMPLATE/feature_request.yml \
             -e 's/PARSER_NAME/${{env.PARSER_NAME}}/g'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# tree-sitter-PARSER_NAME
+# REPO_NAME
 
-[![CI][ci]](https://github.com/tree-sitter-grammars/tree-sitter-PARSER_NAME/actions/workflows/ci.yml)
+[![CI][ci]](https://github.com/tree-sitter-grammars/REPO_NAME/actions/workflows/ci.yml)
 [![discord][discord]](https://discord.gg/w7nTvsVJhm)
 [![matrix][matrix]](https://matrix.to/#/#tree-sitter-chat:matrix.org)
 <!-- NOTE: uncomment these if you're publishing packages: -->
-<!-- [![npm][npm]](https://www.npmjs.com/package/tree-sitter-PARSER_NAME) -->
-<!-- [![crates][crates]](https://crates.io/crates/tree-sitter-PARSER_NAME) -->
-<!-- [![pypi][pypi]](https://pypi.org/project/tree-sitter-PARSER_NAME/) -->
+<!-- [![npm][npm]](https://www.npmjs.com/package/REPO_NAME) -->
+<!-- [![crates][crates]](https://crates.io/crates/REPO_NAME) -->
+<!-- [![pypi][pypi]](https://pypi.org/project/REPO_NAME/) -->
 
 A tree-sitter parser for PARSER_NAME files.
 
@@ -14,9 +14,9 @@ A tree-sitter parser for PARSER_NAME files.
 
 <!-- NOTE: add the grammar's references here -->
 
-[ci]: https://img.shields.io/github/actions/workflow/status/tree-sitter-grammars/tree-sitter-PARSER_NAME/ci.yml?logo=github&label=CI
+[ci]: https://img.shields.io/github/actions/workflow/status/tree-sitter-grammars/REPO_NAME/ci.yml?logo=github&label=CI
 [discord]: https://img.shields.io/discord/1063097320771698699?logo=discord&label=discord
 [matrix]: https://img.shields.io/matrix/tree-sitter-chat%3Amatrix.org?logo=matrix&label=matrix
-[npm]: https://img.shields.io/npm/v/tree-sitter-PARSER_NAME?logo=npm
-[crates]: https://img.shields.io/crates/v/tree-sitter-PARSER_NAME?logo=rust
-[pypi]: https://img.shields.io/pypi/v/tree-sitter-PARSER_NAME?logo=pypi&logoColor=ffd242
+[npm]: https://img.shields.io/npm/v/REPO_NAME?logo=npm
+[crates]: https://img.shields.io/crates/v/REPO_NAME?logo=rust
+[pypi]: https://img.shields.io/pypi/v/REPO_NAME?logo=pypi&logoColor=ffd242


### PR DESCRIPTION
For grammars where the parser name is multiple words separated by a hyphen (e.g. c-sharp in tree-sitter-c-sharp) the PARSER_NAME env var will contain underscores instead (e.g. c_sharp), this cuases the action to generate invalid urls. Solution: Use the actual name of the repository instead.

Other places are changed for consistency, so `tree-sitter-foo-bar` is displayed instead of `tree-sitter-foo_bar`